### PR TITLE
GH-2: Trying to solve install/run error by converting program to use a python package.

### DIFF
--- a/rcl/helpers.py
+++ b/rcl/helpers.py
@@ -3,12 +3,12 @@ import toml
 
 
 CONFIG_FILE = os.path.expanduser("~") + "/.rcl-config"
-BASE_CONFIG = {'entries': {}}
+DEFAULT_CONFIG = {'entries': {}}
 
 
 def check_install():
     if not os.path.isfile(CONFIG_FILE):
-        save_config(BASE_CONFIG)
+        save_config(DEFAULT_CONFIG)
 
 
 def save_config(config):

--- a/rcl/main.py
+++ b/rcl/main.py
@@ -2,10 +2,10 @@
 import os
 
 import click
-import rcl_helpers
+import helpers
 
 # Check the required configuration files exist, and create defaults if not.
-rcl_helpers.check_install()
+helpers.check_install()
 
 
 def echo_data(data):
@@ -24,7 +24,7 @@ def cli():
 @click.argument('remote_path')
 def add(entry_id, local_path, remote_path):
     """Add a new entry."""
-    rcl_helpers.add_entry({
+    helpers.add_entry({
         "id": entry_id,
         "local": local_path,
         "remote": remote_path
@@ -37,7 +37,7 @@ def add(entry_id, local_path, remote_path):
 def remove(entry_id):
     """Remove an entry."""
     try:
-        rcl_helpers.remove_entry(entry_id)
+        helpers.remove_entry(entry_id)
         click.echo("Deleted entry: %s" % entry_id)
     except KeyError:
         click.echo("ERROR: No entry found with id: %s." % entry_id)
@@ -46,7 +46,7 @@ def remove(entry_id):
 @click.command('list')
 def list_entries():
     """List all entries."""
-    config = rcl_helpers.load_config()
+    config = helpers.load_config()
 
     click.echo('\n==== Entries ====\n')
     for entry_id, entry_data in config['entries'].items():
@@ -60,7 +60,7 @@ def list_entries():
 @click.option('--dry/--execute', default=False, help='Run rclone sync with --dry-run flag.')
 def pull(entry_id, dry):
     """Sync local to match remote."""
-    config = rcl_helpers.load_config()
+    config = helpers.load_config()
     entry = config['entries'][entry_id]
 
     if dry:
@@ -74,7 +74,7 @@ def pull(entry_id, dry):
 @click.option('--dry/--execute', default=False, help='Run rclone sync with --dry-run flag.')
 def push(entry_id, dry):
     """Sync remote to match local."""
-    config = rcl_helpers.load_config()
+    config = helpers.load_config()
     entry = config['entries'][entry_id]
 
     if dry:
@@ -87,7 +87,7 @@ def push(entry_id, dry):
 @click.argument('entry_id')
 def diff(entry_id):
     """Show the difference between the local and remote."""
-    config = rcl_helpers.load_config()
+    config = helpers.load_config()
     entry = config['entries'][entry_id]
 
     os.system("rclone check %s %s --dry-run" % (entry['local'], entry['remote']))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='rcl',
-    version='0.1.1',
+    version='0.1.2',
     author='Ben Ryder',
     author_email='dev@benryder.me',
     description='A simple command line wrapper for rclone focused on easy folder syncing',
@@ -13,15 +13,16 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     keywords=['rclone', 'rclone-wrapper'],
     url='https://github.com/Ben-Ryder/rcl',
-    download_url='https://github.com/Ben-Ryder/rcl/archive/v0.1.1.tar.gz',
-    py_modules=['rcl'],
+    download_url='https://github.com/Ben-Ryder/rcl/archive/v0.1.2.tar.gz',
+    packages=setuptools.find_packages(),
+    include_package_data=True,
     install_requires=[
         'Click',
         'toml'
     ],
     entry_points='''
         [console_scripts]
-        rcl=rcl:cli
+        rcl=rcl.main:cli
     ''',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Fixing the error `ModuleNotFoundError: No module named 'rcl_helpers'` being thrown by a cleanly installed rcl by converting the program to use a python package.

This has been tested using [Test PyPI](https://test.pypi.org/project/rcl/) (`pip install -i https://test.pypi.org/simple/ rcl`) on my Ubuntu 18.04 environment, a new live-booted Ubuntu 18.04 and a Mac with Catalina 10.15.6 and it looks to work fine.
It still cause the warning about the install location not being on `$PATH` but this is a separate issue, if it is one.