### PR TITLE
GH-4: Adding config command along with the config item 'editor'.

### DIFF
--- a/rcl/helpers.py
+++ b/rcl/helpers.py
@@ -3,7 +3,7 @@ import toml
 
 
 CONFIG_FILE = os.path.expanduser("~") + "/.rcl-config"
-DEFAULT_CONFIG = {'entries': {}}
+DEFAULT_CONFIG = {'editor': 'nano', 'entries': {}}
 
 
 def check_install():

--- a/rcl/main.py
+++ b/rcl/main.py
@@ -55,6 +55,13 @@ def list_entries():
         click.echo("\n")
 
 
+@click.command('config')
+def open_config():
+    """Open the config file ~/.rcl-config using the editor set in config. Default editor is 'nano'."""
+    config = helpers.load_config()
+    os.system("%s %s" % (config['editor'], helpers.CONFIG_FILE))
+
+
 @click.command()
 @click.argument('entry_id')
 @click.option('--dry/--execute', default=False, help='Run rclone sync with --dry-run flag.')
@@ -99,6 +106,7 @@ cli.add_command(list_entries)
 cli.add_command(pull)
 cli.add_command(push)
 cli.add_command(diff)
+cli.add_command(open_config)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding the `rcl config` command as detailed in GH-4:

> The rcl config command will open the config file for simplicity rather than rcl reading in and outputting the file. A default editor of nano will be set in configuration which can be edited in the ~/.rcl-config file.