### PR TITLE
GH-5: Added setup command which installs rclone and runs the config.

### DIFF
--- a/rcl/main.py
+++ b/rcl/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import platform
 import pkg_resources
 
 import click
@@ -23,8 +24,13 @@ def cli():
 @click.command('setup')
 def setup():
     """Install rclone and run the initial config setup."""
-    os.system("curl https://rclone.org/install.sh | sudo bash")
-    os.system("rclone config")
+    operating_system = platform.system()
+    if operating_system != "Linux" or operating_system == "Darwin":
+        os.system("curl https://rclone.org/install.sh | sudo bash")
+        os.system("rclone config")
+    else:
+        click.echo("Your operating system does not support rcl's automated rclone install. \n"
+                   "To install rclone refer to the documentation here: https://rclone.org/downloads/.")
 
 
 @click.command()

--- a/rcl/main.py
+++ b/rcl/main.py
@@ -20,6 +20,13 @@ def cli():
     pass
 
 
+@click.command('setup')
+def setup():
+    """Install rclone and run the initial config setup."""
+    os.system("curl https://rclone.org/install.sh | sudo bash")
+    os.system("rclone config")
+
+
 @click.command()
 @click.argument('entry_id')
 @click.argument('local_path')
@@ -108,6 +115,7 @@ def diff(entry_id):
     os.system("rclone check %s %s --dry-run" % (entry['local'], entry['remote']))
 
 
+cli.add_command(setup)
 cli.add_command(add)
 cli.add_command(remove)
 cli.add_command(view_entries)


### PR DESCRIPTION
Added `rcl setup` as described in GH-5:

> Add an rcl setup command which will install rclone and run the inital config setup.
> 
> I plan to have the setup use the script install. (curl https://rclone.org/install.sh | sudo bash)
> The "initial config setup" will simply be rcl calling rclone config. rclone will still have to be configured manually following the documentation.